### PR TITLE
Link NPM to GitHub repository & issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,5 +44,12 @@
   "devDependencies": {
     "eslint": "^4.19.1",
     "husky": "^1.0.0-rc.6"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Rayzr522/zstream-server.git"
+  },
+  "bugs": {
+    "url": "https://github.com/Rayzr522/zstream-server/issues"
   }
 }


### PR DESCRIPTION
After a little d-tour, starting at [zstream-server on npmjs.com],(https://www.npmjs.com/package/zstream-server) figuring out the corresponding [GitHub repository](https://github.com/Rayzr522/zstream-server), I thought, let's fix it.